### PR TITLE
allow raw value to be passed as report in monitor

### DIFF
--- a/lib/VitalSigns.js
+++ b/lib/VitalSigns.js
@@ -135,7 +135,9 @@ VitalSigns.prototype._getModuleReport = function(monitor) {
 		return this._getModuleReport(monitor());
 	if (monitor.report && typeof monitor.report == 'function')
 		report = monitor.report();
-	else
+	else if (monitor.report)
+		report = monitor.report;
+	else 
 		report = monitor;
 	for (var field in report) {
 		if (report.hasOwnProperty(field)) {


### PR DESCRIPTION
Allows you do to this:

``` javascript
vitals.monitor({
    name: 'pid',
    report: process.pid 
});
```

Instead of having to do this: (both work still)

``` javascript
vitals.monitor({
    name: 'pid',
   report: function() { return process.pid; }
});
```
